### PR TITLE
Adjust debounce time for lilka v2.3 + 6x6 smd buttons

### DIFF
--- a/sdk/lib/lilka/src/lilka/controller.cpp
+++ b/sdk/lib/lilka/src/lilka/controller.cpp
@@ -115,7 +115,7 @@ void Controller::resetState() {
 }
 
 void Controller::begin() {
-    serial_log("initializing controller");
+    serial.log("initializing controller");
 
 #if LILKA_VERSION == 1
     // Detach UART from GPIO20 & GPIO21 to use them as normal IOs
@@ -138,7 +138,7 @@ void Controller::begin() {
     // Create RTOS task for handling button presses
     xTaskCreate([](void* arg) { static_cast<Controller*>(arg)->inputTask(); }, "input", 2048, this, 1, NULL);
 
-    serial_log("controller ready");
+    serial.log("controller ready");
 }
 
 State Controller::getState() {

--- a/sdk/lib/lilka/src/lilka/controller.h
+++ b/sdk/lib/lilka/src/lilka/controller.h
@@ -24,7 +24,7 @@ typedef enum {
     COUNT,
 } Button;
 
-#define LILKA_DEBOUNCE_TIME 10 // 10ms
+#define LILKA_DEBOUNCE_TIME 100 // Limit to not more than 10 button clicks per second for a button
 
 /// Містить стан кнопки, який був вимінярий в певний момент часу.
 typedef struct {


### PR DESCRIPTION
There's no real reason to support 100 state changes for a button per second
while decreasing this value could improve their usage experience.
